### PR TITLE
Add photon conversion info

### DIFF
--- a/TiCLTreeProducer/interface/LightTree.h
+++ b/TiCLTreeProducer/interface/LightTree.h
@@ -41,7 +41,7 @@ class LightTree {
   void fillTriplets(const std::vector< std::vector<Triplet> > & aTripletVec);
   
   
-  void fillCPinfo(const std::vector<caloparticle> & caloparticles);
+  void fillCPinfo(const std::vector<caloparticle> & caloparticles, const std::vector<float> dzs);
 
   void fillSCinfo(const std::vector<simcluster> & simclusters);
 
@@ -109,6 +109,7 @@ class LightTree {
   std::vector<double> cp_pt;
   std::vector<double> cp_eta;
   std::vector<double> cp_phi;
+  std::vector<double> cp_convAbsDz;
 
   int nSC;
   std::vector<int> sc_CPidx;

--- a/TiCLTreeProducer/plugins/BuildFile.xml
+++ b/TiCLTreeProducer/plugins/BuildFile.xml
@@ -36,6 +36,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="RecoEgamma/EgammaMCTools"/>
 <flags   EDM_PLUGIN="1"/>
 <Flags CXXFLAGS="-O0"/>
 <Flags CXXFLAGS="-g"/>

--- a/TiCLTreeProducer/python/TiCLTreeProducer_cfi.py
+++ b/TiCLTreeProducer/python/TiCLTreeProducer_cfi.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 ticlTree = cms.EDAnalyzer('TiCLTreeProducer',
                      caloParticles      = cms.InputTag("mix"                , "MergedCaloTruth"),
+                     genParticles       = cms.InputTag("genParticles"                , "", "HLT"),
+                     simTracks          = cms.InputTag("g4SimHits"                , "", "SIM"),
+                     simVertices        = cms.InputTag("g4SimHits"                , "", "SIM"),
                      simClusters        = cms.InputTag("mix"                , "MergedCaloTruth"),
                      hgcalRecHitsEE     = cms.InputTag("HGCalRecHit"        , "HGCEERecHits"),
                      hgcalRecHitsFH     = cms.InputTag("HGCalRecHit"        , "HGCHEFRecHits"),

--- a/TiCLTreeProducer/src/LightTree.cc
+++ b/TiCLTreeProducer/src/LightTree.cc
@@ -95,6 +95,7 @@ void LightTree::makeTree(edm::Service<TFileService> & aFile,
   outputTree->Branch("cp_pt", &cp_pt);
   outputTree->Branch("cp_eta", &cp_eta);
   outputTree->Branch("cp_phi", &cp_phi);
+  outputTree->Branch("cp_convAbsDz", &cp_convAbsDz);
   outputTree->Branch("cp_pdgid", &cp_pdgid);
   
   outputTree->Branch("nSC", &nSC, "nSC/I");
@@ -228,6 +229,7 @@ void LightTree::initialiseTreeVariables(const size_t irun,
   cp_pt.clear();
   cp_eta.clear();
   cp_phi.clear();
+  cp_convAbsDz.clear();
 
   nSC = 0;
   sc_CPidx.clear();
@@ -330,7 +332,7 @@ void LightTree::fillTriplets(const std::vector< std::vector<Triplet> > & aTriple
 }
 
 
-void LightTree::fillCPinfo(const std::vector<caloparticle> & caloparticles){
+void LightTree::fillCPinfo(const std::vector<caloparticle> & caloparticles, const std::vector<float> dzs){
   nCP = caloparticles.size();
   for (int icp = 0; icp < nCP; ++icp) {
     cp_nSC.push_back(caloparticles[icp].nSC_);
@@ -338,6 +340,7 @@ void LightTree::fillCPinfo(const std::vector<caloparticle> & caloparticles){
     cp_pt.push_back(caloparticles[icp].pt_);
     cp_eta.push_back(caloparticles[icp].eta_);
     cp_phi.push_back(caloparticles[icp].phi_);
+    cp_convAbsDz.push_back(dzs[icp]);
     cp_pdgid.push_back(caloparticles[icp].pdgid_);
     cp_missingEnergyFraction.push_back(0);
   }


### PR DESCRIPTION
This uses an existing photon MC truth tool to extract the conversion info from a truth photon matched to the calo particle. It's a bit rough for now but works in providing a z value for where the photon interacted, which can be used to figure out whether a conversion occurred upstream of the HGCAL. If we need more info on that vertex it can be added easily. 

This requires extra info to be stored in the step3ticl files (SimTracks and SimVertices) so it won't work on any existing files. I'll make the corresponding PR to the ticl-only config shortly. 